### PR TITLE
fixes kube subcommand multiconfig support

### DIFF
--- a/cmd/kube.go
+++ b/cmd/kube.go
@@ -4,13 +4,19 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/Shopify/vouch4cluster/listers/kubernetes"
+	k8slister "github.com/Shopify/vouch4cluster/listers/kubernetes"
 	"github.com/Shopify/vouch4cluster/process"
-	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
-)
 
-var kubeCfgFile string
+	"k8s.io/client-go/kubernetes"
+
+	"k8s.io/client-go/tools/clientcmd"
+
+	// add GCP authentication support to the kubernetes code
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
 
 // kubeCmd represents the kube command
 var kubeCmd = &cobra.Command{
@@ -18,26 +24,26 @@ var kubeCmd = &cobra.Command{
 	Short: "Attest all images in the current cluster",
 	Long:  `Connects to kubernetes and attests all images in the currently configured context.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		if "" == kubeCfgFile {
-			home, err := homedir.Dir()
-			if err != nil {
-				errorf("failed to get default kubeconfig: %s", err)
-				os.Exit(1)
-			}
-
-			kubeCfgFile = home + "/.kube/config"
-		}
-
 		cfg := getVoucherCfg()
 
 		var err error
-		k8sLister, err := kubernetes.NewImageLister(kubeCfgFile)
+
+		kubeconfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+			clientcmd.NewDefaultClientConfigLoadingRules(),
+			&clientcmd.ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: ""}},
+		).ClientConfig()
 		if nil != err {
-			errorf("getting kubernetes image lister failed: %s", err)
+			errorf("loading Kubernetes config failed: %s", err)
 			os.Exit(1)
 		}
 
-		err = process.LookupAndAttest(cfg, k8sLister, os.Stdout)
+		client, err := kubernetes.NewForConfig(kubeconfig)
+		if nil != err {
+			errorf("initializing Kubernetes client failed: %s", err)
+			os.Exit(1)
+		}
+
+		err = process.LookupAndAttest(cfg, k8slister.NewImageLister(client), os.Stdout)
 		if nil != err {
 			fmt.Printf("attesting images failed: %s\n", err)
 			os.Exit(1)
@@ -47,5 +53,4 @@ var kubeCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(kubeCmd)
-	kubeCmd.Flags().StringVarP(&kubeCfgFile, "kubeconfig", "k", "", "kubernetes configuration file (default is $HOME/.kube/config")
 }

--- a/listers/kubernetes/k8s.go
+++ b/listers/kubernetes/k8s.go
@@ -4,16 +4,11 @@ import (
 	"github.com/Shopify/vouch4cluster/listers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-
-	// add GCP authentication support to the kubernetes code
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
 // k8sImageLister lists images running in Kubernetes.
 type k8sImageLister struct {
-	client *kubernetes.Clientset
+	client kubernetes.Interface
 }
 
 // List returns a list of all of the images available to the current Kubernetes context,
@@ -43,18 +38,12 @@ func (k *k8sImageLister) List() ([]string, error) {
 	return uniqueImages, err
 }
 
-// NewImageLister creates a new Kubernetes specific ImageLister
-func NewImageLister(configFilename string) (listers.ImageLister, error) {
-	k := new(k8sImageLister)
-
-	kubeconfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		&clientcmd.ClientConfigLoadingRules{ExplicitPath: configFilename},
-		&clientcmd.ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: ""}},
-	).ClientConfig()
-	if nil != err {
-		return nil, err
+// NewImageLister creates a new Kubernetes specific ImageLister with the passed
+// kubernetes.Interface.
+func NewImageLister(clientSet kubernetes.Interface) listers.ImageLister {
+	k := &k8sImageLister{
+		client: clientSet,
 	}
 
-	k.client, err = kubernetes.NewForConfig(kubeconfig)
-	return k, err
+	return k
 }


### PR DESCRIPTION
This change fixes the `kube` subcommand's configuration handling to respect the `KUBECONFIG` environment variable, rather than ignoring it.

This fixes https://github.com/Shopify/vouch4cluster/issues/2.